### PR TITLE
In-memory FactStore clear

### DIFF
--- a/factcast-store-inmem/src/main/java/org/factcast/store/inmem/InMemFactStore.java
+++ b/factcast-store-inmem/src/main/java/org/factcast/store/inmem/InMemFactStore.java
@@ -217,4 +217,7 @@ public class InMemFactStore implements FactStore, DisposableBean {
         return OptionalLong.empty();
     }
 
+    public void clear() {
+        this.store.clear();
+    }
 }


### PR DESCRIPTION
I'd like to have a way to clear the events in an InMemFactStore for testing purposes. 

Let's say you have a spring application and you want to test the integration of various classes that read from and write to factcast. I.e. given that certain events are already present in the factcast, you'd expect certain other events to be written to the factcast.

Right now the only (non-hacky) way I see to properly clean up after tests is to throw the entire context away.
