### PR TITLE
Update maven-[surefire,failsafe]-plugin to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,14 +164,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.21.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${junit.platform.version}</version>
-          </dependency>
-        </dependencies>
+        <version>2.22.0</version>
         <configuration>
           <argLine>-Xmx1600m</argLine>
           <forkCount>1</forkCount>
@@ -184,7 +177,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.0</version>
         <configuration>
           <includes>
             <include>**/*IT.java</include>


### PR DESCRIPTION
This gets us rid of the build warning, that junit-platform-surefire-provider
will be deprecated with junit-platform:1.4.0.

```
 +-------------------------------------------------------------------------------+
 | WARNING:                                                                      |
 | The junit-platform-surefire-provider has been deprecated and is scheduled to  |
 | be removed in JUnit Platform 1.4. Please use the built-in support in Maven    |
 | Surefire >= 2.22.0 instead.                                                   |
 | » https://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven |
 +-------------------------------------------------------------------------------+
```