### PR TITLE
[WIP] Spring Boot 2

### DIFF
--- a/factcast-client-cache/src/test/java/org/factcast/client/cache/CachingFactCast0Test.java
+++ b/factcast-client-cache/src/test/java/org/factcast/client/cache/CachingFactCast0Test.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CachingFactCast0Test {

--- a/factcast-client-cache/src/test/java/org/factcast/client/cache/CachingFactLookup0Test.java
+++ b/factcast-client-cache/src/test/java/org/factcast/client/cache/CachingFactLookup0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.client.cache;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
@@ -13,7 +13,7 @@ import org.factcast.core.store.FactStore;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CachingFactLookup0Test {

--- a/factcast-client-grpc/pom.xml
+++ b/factcast-client-grpc/pom.xml
@@ -9,7 +9,8 @@
   </parent>
   <artifactId>factcast-client-grpc</artifactId>
   <properties>
-    <powermock.version>1.7.0RC4</powermock.version>
+    <!-- https://github.com/powermock/powermock/issues/867 -->
+    <powermock.version>2.0.0-beta.5</powermock.version>
   </properties>
   <dependencies>
     <dependency>
@@ -47,14 +48,9 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/factcast-client-grpc/src/test/java/org/factcast/client/grpc/ClientStreamObserver0Test.java
+++ b/factcast-client-grpc/src/test/java/org/factcast/client/grpc/ClientStreamObserver0Test.java
@@ -1,6 +1,5 @@
 package org.factcast.client.grpc;
 
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -16,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientStreamObserver0Test {

--- a/factcast-core/src/test/java/org/factcast/core/DefaultFactCast0Test.java
+++ b/factcast-core/src/test/java/org/factcast/core/DefaultFactCast0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.core;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -21,7 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultFactCast0Test {
@@ -50,8 +50,7 @@ public class DefaultFactCast0Test {
 
         final UUID since = UUID.randomUUID();
         SubscriptionRequest r = SubscriptionRequest.follow(FactSpec.forMark())
-                .or(FactSpec.ns(
-                        "some").type("type"))
+                .or(FactSpec.ns("some").type("type"))
                 .from(since);
 
         uut.subscribeToFacts(r, f -> {
@@ -71,8 +70,7 @@ public class DefaultFactCast0Test {
         when(store.subscribe(csr.capture(), any())).thenReturn(mock(Subscription.class));
 
         SubscriptionRequest r = SubscriptionRequest.follow(FactSpec.forMark())
-                .or(FactSpec.ns(
-                        "some").type("type"))
+                .or(FactSpec.ns("some").type("type"))
                 .fromScratch();
 
         uut.subscribeToIds(r, f -> {

--- a/factcast-core/src/test/java/org/factcast/core/FactCast0Test.java
+++ b/factcast-core/src/test/java/org/factcast/core/FactCast0Test.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FactCast0Test {

--- a/factcast-core/src/test/java/org/factcast/core/subscription/SubscriptionImpl0Test.java
+++ b/factcast-core/src/test/java/org/factcast/core/subscription/SubscriptionImpl0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.core.subscription;
 
 import static org.factcast.core.TestHelper.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CountDownLatch;
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SubscriptionImpl0Test {

--- a/factcast-core/src/test/java/org/factcast/core/subscription/observer/GenericObserver0Test.java
+++ b/factcast-core/src/test/java/org/factcast/core/subscription/observer/GenericObserver0Test.java
@@ -1,6 +1,6 @@
 package org.factcast.core.subscription.observer;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.factcast.core.Test0Fact;

--- a/factcast-examples/factcast-example-server/pom.xml
+++ b/factcast-examples/factcast-example-server/pom.xml
@@ -38,11 +38,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>1.5.2.RELEASE</version>
-        <configuration>
-          <mainClass>org.factcast.example.server.Application</mainClass>
-          <layout>ZIP</layout>
-        </configuration>
+        <version>${spring-boot.version}</version>
         <executions>
           <execution>
             <goals>

--- a/factcast-examples/factcast-example-server/src/main/java/org/factcast/example/server/Application.java
+++ b/factcast-examples/factcast-example-server/src/main/java/org/factcast/example/server/Application.java
@@ -16,10 +16,10 @@
 package org.factcast.example.server;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.web.ErrorMvcAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+
+import com.codahale.metrics.MetricRegistry;
 
 /**
  * Spring boot starter for running a factcast server.
@@ -30,10 +30,16 @@ import org.springframework.context.annotation.Configuration;
  *
  */
 @SpringBootApplication
-@EnableAutoConfiguration(exclude = ErrorMvcAutoConfiguration.class)
-@Configuration
 public class Application {
+
     public static void main(String[] args) {
         SpringApplication.run(Application.class);
     }
+
+    // FIXME drop this after switch to micrometer
+    @Bean
+    MetricRegistry metricRegistry() {
+        return new MetricRegistry();
+    }
+
 }

--- a/factcast-server-grpc/src/test/java/org/factcast/server/grpc/BlockingStreamObserver0Test.java
+++ b/factcast-server-grpc/src/test/java/org/factcast/server/grpc/BlockingStreamObserver0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.server.grpc;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.CompletableFuture;
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.grpc.stub.ServerCallStreamObserver;
 

--- a/factcast-server-grpc/src/test/java/org/factcast/server/grpc/FactStoreGrpcService0Test.java
+++ b/factcast-server-grpc/src/test/java/org/factcast/server/grpc/FactStoreGrpcService0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.server.grpc;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;

--- a/factcast-server-grpc/src/test/java/org/factcast/server/grpc/GrpcObserverAdapter0Test.java
+++ b/factcast-server-grpc/src/test/java/org/factcast/server/grpc/GrpcObserverAdapter0Test.java
@@ -2,7 +2,7 @@ package org.factcast.server.grpc;
 
 import static org.factcast.core.TestHelper.*;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.function.Function;
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.grpc.stub.StreamObserver;
 

--- a/factcast-store-pgsql/pom.xml
+++ b/factcast-store-pgsql/pom.xml
@@ -34,10 +34,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>

--- a/factcast-store-pgsql/pom.xml
+++ b/factcast-store-pgsql/pom.xml
@@ -36,6 +36,17 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- FIXME get rid of tomcat-jdbc -->
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -45,23 +56,10 @@
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
       <version>3.6.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.postgres</groupId>
-          <artifactId>postgres</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.1.1</version>
-      <!--$NO-MVN-MAN-VER$ -->
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgConnectionSupplier.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgConnectionSupplier.java
@@ -20,11 +20,11 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.inject.Inject;
 import javax.sql.DataSource;
 
 import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.postgresql.jdbc.PgConnection;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -42,15 +42,15 @@ public class PgConnectionSupplier {
     @NonNull
     private final org.apache.tomcat.jdbc.pool.DataSource ds;
 
-    @Inject
+    @Autowired
     PgConnectionSupplier(@NonNull DataSource dataSource) {
 
         if (dataSource instanceof org.apache.tomcat.jdbc.pool.DataSource) {
             this.ds = (org.apache.tomcat.jdbc.pool.DataSource) dataSource;
         } else {
-            throw new IllegalStateException("expected "
-                    + org.apache.tomcat.jdbc.pool.DataSource.class.getName()
-                    + " , but got " + dataSource.getClass().getName());
+            throw new IllegalStateException(
+                    "expected " + org.apache.tomcat.jdbc.pool.DataSource.class.getName()
+                            + " , but got " + dataSource.getClass().getName());
         }
     }
 
@@ -88,15 +88,15 @@ public class PgConnectionSupplier {
                             .withKeyValueSeparator("=")
                             .split(connectionProperties);
 
-                    setProperty(dbp, "socketTimeout", singleConnectionProperties.get(
-                            "socketTimeout"));
-                    setProperty(dbp, "connectTimeout", singleConnectionProperties.get(
-                            "connectTimeout"));
-                    setProperty(dbp, "loginTimeout", singleConnectionProperties.get(
-                            "loginTimeout"));
+                    setProperty(dbp, "socketTimeout",
+                            singleConnectionProperties.get("socketTimeout"));
+                    setProperty(dbp, "connectTimeout",
+                            singleConnectionProperties.get("connectTimeout"));
+                    setProperty(dbp, "loginTimeout",
+                            singleConnectionProperties.get("loginTimeout"));
                 } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("illegal connectionProperties: "
-                            + connectionProperties);
+                    throw new IllegalArgumentException(
+                            "illegal connectionProperties: " + connectionProperties);
                 }
             }
         }

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/CondensedQueryExecutor0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/CondensedQueryExecutor0Test.java
@@ -1,6 +1,6 @@
 package org.factcast.store.pgsql.internal;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Timer;
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CondensedQueryExecutor0Test {

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGFact0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGFact0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.store.pgsql.internal;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.sql.ResultSet;

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGLatestSerialFetcher0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGLatestSerialFetcher0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.store.pgsql.internal;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.UUID;

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGQuery3IT.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGQuery3IT.java
@@ -1,6 +1,6 @@
 package org.factcast.store.pgsql.internal;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.UUID;

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGSqlListener0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGSqlListener0Test.java
@@ -1,6 +1,6 @@
 package org.factcast.store.pgsql.internal;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.sql.Connection;
@@ -18,7 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.postgresql.PGNotification;
 import org.postgresql.core.Notification;
 import org.postgresql.jdbc.PgConnection;

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGSqlListener0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/PGSqlListener0Test.java
@@ -137,8 +137,6 @@ public class PGSqlListener0Test {
 
     @Test
     public void testStopWithoutStarting() throws Exception {
-        Mockito.when(ds.get()).thenReturn(conn);
-        Mockito.when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
         PGListener l = new PGListener(ds, bus, tester);
         l.destroy();
 

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/catchup/paged/PGCatchUpFetchPage0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/catchup/paged/PGCatchUpFetchPage0Test.java
@@ -1,6 +1,6 @@
 package org.factcast.store.pgsql.internal.catchup.paged;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -14,7 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/catchup/queue/PGQueueCatchup0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/catchup/queue/PGQueueCatchup0Test.java
@@ -1,6 +1,6 @@
 package org.factcast.store.pgsql.internal.catchup.queue;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PGConnectionTester0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PGConnectionTester0Test.java
@@ -1,7 +1,7 @@
 package org.factcast.store.pgsql.internal.listen;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.sql.Connection;
@@ -14,7 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGFactExtractor0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGFactExtractor0Test.java
@@ -13,7 +13,7 @@ import org.factcast.store.pgsql.internal.PGConstants;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PGFactExtractor0Test {

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGFactExtractor0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGFactExtractor0Test.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.factcast.core.Fact;
 import org.factcast.store.pgsql.internal.PGConstants;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -22,14 +21,10 @@ public class PGFactExtractor0Test {
 
     private PGFactExtractor uut = new PGFactExtractor(serial);
 
-    @Before
-    public void setUp() throws Exception {
-    }
-
     @Test
     public void testMapRow() throws Exception {
+        @SuppressWarnings("resource")
         ResultSet rs = mock(ResultSet.class);
-        when(rs.next()).thenReturn(true, false);
         final UUID id = UUID.randomUUID();
         when(rs.getString(PGConstants.ALIAS_ID)).thenReturn(id.toString());
         when(rs.getString(PGConstants.ALIAS_NS)).thenReturn("ns");

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGIdFactExtractor0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGIdFactExtractor0Test.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.factcast.core.Fact;
 import org.factcast.store.pgsql.internal.PGConstants;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -21,14 +20,10 @@ public class PGIdFactExtractor0Test {
 
     private PGIdFactExtractor uut = new PGIdFactExtractor(serial);
 
-    @Before
-    public void setUp() throws Exception {
-    }
-
     @Test
     public void testMapRow() throws Exception {
+        @SuppressWarnings("resource")
         ResultSet rs = mock(ResultSet.class);
-        when(rs.next()).thenReturn(true, false);
         final UUID id = UUID.randomUUID();
         when(rs.getString(PGConstants.ALIAS_ID)).thenReturn(id.toString());
         when(rs.getLong(PGConstants.COLUMN_SER)).thenReturn(27L);

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGIdFactExtractor0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/rowmapper/PGIdFactExtractor0Test.java
@@ -12,7 +12,7 @@ import org.factcast.store.pgsql.internal.PGConstants;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PGIdFactExtractor0Test {

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
   </developers>
   <properties>
     <grpc.version>1.12.0</grpc.version>
-    <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
-    <spring-cloud.version>Edgware.SR1</spring-cloud.version>
+    <spring-boot.version>2.0.6.RELEASE</spring-boot.version>
+    <spring-cloud.version>Finchley.SR1</spring-cloud.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <formatter.config>${project.parent.basedir}/src/eclipse/config/</formatter.config>
@@ -78,6 +78,11 @@
         <version>${spring-cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>1.18.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -99,6 +104,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <version>26.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -114,7 +120,6 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
-      <version>1.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -174,7 +179,6 @@
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -220,12 +224,9 @@
               <pluginExecutions>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId> org.commonjava.maven.plugins 
-										</groupId>
-                    <artifactId> directory-maven-plugin 
-										</artifactId>
-                    <versionRange> [0.3.1,) 
-										</versionRange>
+                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <artifactId>directory-maven-plugin</artifactId>
+                    <versionRange>[0.3.1,)</versionRange>
                     <goals>
                       <goal>highest-basedir</goal>
                     </goals>
@@ -236,12 +237,9 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId> org.apache.maven.plugins 
-										</groupId>
-                    <artifactId> maven-enforcer-plugin 
-										</artifactId>
-                    <versionRange> [1.0,) 
-										</versionRange>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <versionRange>[1.0,)</versionRange>
                     <goals>
                       <goal>enforce</goal>
                     </goals>


### PR DESCRIPTION
Up for review.

Some points:
* straight and dirty
* looking at the current dependencies was a nightmare (and I didn't wanna touch anything I saw there)
* after this I propose the examine the possibility of a `factcast-spring-boot` module which contains all auto configurations so that we can "de-boot" everything except where **really** reguired
* the powermock switch to `2.0.0-beta.5` brings up some mixed feelings, as it doesn't sound to be pursued anymore (couldn't solve Mockito API problems during tests otherwise; see the linked ticket in the pom.xml)
* later: get rid of dropwizard
* later: move to Spring Boot 2.1 (when ready; scheduled for end of October but likely delayed as usual)
* later: get rid of `tomcat-jdbc` (I am sure the Spring guys had a reason to use `HikariCP` as the default in Spring Boot 2; would required re-investigation regarding setting timeouts (I have forgotten what was possible.))

Resolves #78.