### PR TITLE
Update Spotless Eclipse Formatter to 4.11

### DIFF
--- a/factcast-client-grpc-cli/src/main/java/org/factcast/client/grpc/cli/cmd/Fetch.java
+++ b/factcast-client-grpc-cli/src/main/java/org/factcast/client/grpc/cli/cmd/Fetch.java
@@ -39,7 +39,8 @@ public class Fetch implements Command {
     @Override
     public void runWith(FactCast fc, Options opt) {
         FactRenderer factRenderer = new FactRenderer(opt);
-        ids.forEach(id -> System.out.println(fc.fetchById(id).map(factRenderer::render).orElse(
-                "not found")));
+        ids.forEach(id -> System.out.println(fc.fetchById(id)
+                .map(factRenderer::render)
+                .orElse("not found")));
     }
 }

--- a/factcast-client-grpc/src/main/java/org/factcast/client/grpc/ClientStreamObserver.java
+++ b/factcast-client-grpc/src/main/java/org/factcast/client/grpc/ClientStreamObserver.java
@@ -24,7 +24,6 @@ import org.factcast.grpc.api.gen.FactStoreProto;
 import org.factcast.grpc.api.gen.FactStoreProto.MSG_Notification;
 
 import io.grpc.stub.StreamObserver;
-
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/factcast-client-grpc/src/main/java/org/factcast/client/grpc/FactCastGrpcChannelFactory.java
+++ b/factcast-client-grpc/src/main/java/org/factcast/client/grpc/FactCastGrpcChannelFactory.java
@@ -24,8 +24,8 @@ import io.grpc.ManagedChannel;
 public interface FactCastGrpcChannelFactory extends AutoCloseable {
 
     /**
-     * Creates a new channel for the given service name. The returned channel will
-     * use all globally registered {@link ClientInterceptor}s.
+     * Creates a new channel for the given service name. The returned channel
+     * will use all globally registered {@link ClientInterceptor}s.
      *
      * <p>
      * <b>Note:</b> The underlying implementation might reuse existing
@@ -39,8 +39,8 @@ public interface FactCastGrpcChannelFactory extends AutoCloseable {
     Channel createChannel(String name);
 
     /**
-     * Creates a new channel for the given service name. The returned channel will
-     * use all globally registered {@link ClientInterceptor}s.
+     * Creates a new channel for the given service name. The returned channel
+     * will use all globally registered {@link ClientInterceptor}s.
      *
      * <p>
      * <b>Note:</b> The underlying implementation might reuse existing
@@ -56,8 +56,8 @@ public interface FactCastGrpcChannelFactory extends AutoCloseable {
      * @param name
      *            The name of the service.
      * @param interceptors
-     *            A list of additional client interceptors that should be added to
-     *            the channel.
+     *            A list of additional client interceptors that should be added
+     *            to the channel.
      * @return The newly created channel for the given service.
      */
     @SuppressWarnings("unused")

--- a/factcast-client-grpc/src/main/java/org/factcast/client/grpc/GrpcFactStore.java
+++ b/factcast-client-grpc/src/main/java/org/factcast/client/grpc/GrpcFactStore.java
@@ -40,7 +40,6 @@ import com.google.common.collect.*;
 import io.grpc.*;
 import io.grpc.Status.*;
 import io.grpc.stub.*;
-
 import lombok.*;
 import lombok.extern.slf4j.*;
 import net.devh.boot.grpc.client.security.*;

--- a/factcast-core/src/main/java/org/factcast/core/lock/Attempt.java
+++ b/factcast-core/src/main/java/org/factcast/core/lock/Attempt.java
@@ -29,8 +29,8 @@ public interface Attempt {
 
     /**
      * this is only a convenience method. You can choose to throw
-     * AttemptAbortedException from your lambda yourself or use custom subclasses in
-     * order to pass additional info out of your lamdba.
+     * AttemptAbortedException from your lambda yourself or use custom
+     * subclasses in order to pass additional info out of your lamdba.
      *
      * @param msg
      *            String messgae to be passed into Exception

--- a/factcast-core/src/main/java/org/factcast/core/lock/LockedOperationBuilder.java
+++ b/factcast-core/src/main/java/org/factcast/core/lock/LockedOperationBuilder.java
@@ -54,8 +54,9 @@ public final class LockedOperationBuilder {
         // we MIGHT add pessimistic if we REALLY REALLY have to
 
         /**
-         * convenience method that uses optimistic locking with defaults. Alternatively,
-         * you can call optimistic() to get control over the optimistic settings.
+         * convenience method that uses optimistic locking with defaults.
+         * Alternatively, you can call optimistic() to get control over the
+         * optimistic settings.
          *
          * @param operation
          *            will be attempted to be executed, maybe many times

--- a/factcast-core/src/main/java/org/factcast/core/spec/FactSpecMatcher.java
+++ b/factcast-core/src/main/java/org/factcast/core/spec/FactSpecMatcher.java
@@ -85,8 +85,7 @@ public final class FactSpecMatcher implements Predicate<Fact> {
         if ((meta.isEmpty())) {
             return true;
         }
-        return meta.entrySet().stream().allMatch(e -> e.getValue().equals(t.meta(e
-                .getKey())));
+        return meta.entrySet().stream().allMatch(e -> e.getValue().equals(t.meta(e.getKey())));
     }
 
     protected boolean nsMatch(Fact t) {
@@ -135,8 +134,9 @@ public final class FactSpecMatcher implements Predicate<Fact> {
     }
 
     public static Predicate<Fact> matchesAnyOf(@NonNull List<FactSpec> spec) {
-        List<FactSpecMatcher> matchers = spec.stream().map(FactSpecMatcher::new).collect(Collectors
-                .toList());
+        List<FactSpecMatcher> matchers = spec.stream()
+                .map(FactSpecMatcher::new)
+                .collect(Collectors.toList());
         return f -> matchers.stream().anyMatch(p -> p.test(f));
     }
 

--- a/factcast-core/src/main/java/org/factcast/core/subscription/FluentSubscriptionRequest.java
+++ b/factcast-core/src/main/java/org/factcast/core/subscription/FluentSubscriptionRequest.java
@@ -59,9 +59,9 @@ class FluentSubscriptionRequest implements SubscriptionRequest {
 
     private String createDebugInfo() {
         StackTraceElement stackTraceElement = new Exception().getStackTrace()[3];
-        return UUID.randomUUID() + " (" + stackTraceElement.getClassName().substring(
-                stackTraceElement.getClassName().lastIndexOf(".") + 1) + "." + stackTraceElement
-                        .getMethodName() + ":" + stackTraceElement.getLineNumber() + ")";
+        return UUID.randomUUID() + " (" + stackTraceElement.getClassName()
+                .substring(stackTraceElement.getClassName().lastIndexOf(".") + 1) + "."
+                + stackTraceElement.getMethodName() + ":" + stackTraceElement.getLineNumber() + ")";
     }
 
     @RequiredArgsConstructor

--- a/factcast-core/src/main/java/org/factcast/core/subscription/SubscriptionImpl.java
+++ b/factcast-core/src/main/java/org/factcast/core/subscription/SubscriptionImpl.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.factcast.core.subscription.observer.GenericObserver;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/factcast-examples/factcast-example-client-basicauth/src/main/java/org/factcast/example/client/basicauth/HelloWorldRunner.java
+++ b/factcast-examples/factcast-example-client-basicauth/src/main/java/org/factcast/example/client/basicauth/HelloWorldRunner.java
@@ -60,20 +60,26 @@ public class HelloWorldRunner implements CommandLineRunner {
 
         UUID id = UUID.randomUUID();
         System.out.println("trying to publish with optimistic locking");
-        UUID success = fc.lock("foo").on(id).optimistic().attempt(() -> Attempt.publish(Fact
-                .builder()
-                .aggId(id)
-                .ns("foo")
-                .buildWithoutPayload()));
+        UUID success = fc.lock("foo")
+                .on(id)
+                .optimistic()
+                .attempt(() -> Attempt.publish(Fact
+                        .builder()
+                        .aggId(id)
+                        .ns("foo")
+                        .buildWithoutPayload()));
         System.out.println("published succeeded: " + (success != null));
         System.out.println("published id: " + success);
         expected.add(success);
 
         System.out.println("trying another with optimistic locking");
-        success = fc.lock("foo").on(id).optimistic().attempt(() -> Attempt.publish(Fact.builder()
-                .aggId(id)
-                .ns("foo")
-                .buildWithoutPayload()));
+        success = fc.lock("foo")
+                .on(id)
+                .optimistic()
+                .attempt(() -> Attempt.publish(Fact.builder()
+                        .aggId(id)
+                        .ns("foo")
+                        .buildWithoutPayload()));
         System.out.println("published succeeded: " + (success != null));
         System.out.println("published id: " + success);
         expected.add(success);

--- a/factcast-examples/factcast-example-client-spring-boot2/src/main/java/org/factcast/example/client/spring/boot2/hello/HelloWorldRunner.java
+++ b/factcast-examples/factcast-example-client-spring-boot2/src/main/java/org/factcast/example/client/spring/boot2/hello/HelloWorldRunner.java
@@ -60,20 +60,26 @@ public class HelloWorldRunner implements CommandLineRunner {
 
         UUID id = UUID.randomUUID();
         System.out.println("trying to publish with optimistic locking");
-        UUID success = fc.lock("foo").on(id).optimistic().attempt(() -> Attempt.publish(Fact
-                .builder()
-                .aggId(id)
-                .ns("foo")
-                .buildWithoutPayload()));
+        UUID success = fc.lock("foo")
+                .on(id)
+                .optimistic()
+                .attempt(() -> Attempt.publish(Fact
+                        .builder()
+                        .aggId(id)
+                        .ns("foo")
+                        .buildWithoutPayload()));
         System.out.println("published succeeded: " + (success != null));
         System.out.println("published id: " + success);
         expected.add(success);
 
         System.out.println("trying another with optimistic locking");
-        success = fc.lock("foo").on(id).optimistic().attempt(() -> Attempt.publish(Fact.builder()
-                .aggId(id)
-                .ns("foo")
-                .buildWithoutPayload()));
+        success = fc.lock("foo")
+                .on(id)
+                .optimistic()
+                .attempt(() -> Attempt.publish(Fact.builder()
+                        .aggId(id)
+                        .ns("foo")
+                        .buildWithoutPayload()));
         System.out.println("published succeeded: " + (success != null));
         System.out.println("published id: " + success);
         expected.add(success);

--- a/factcast-grpc-api/src/main/java/org/factcast/grpc/api/conv/ProtoConverter.java
+++ b/factcast-grpc-api/src/main/java/org/factcast/grpc/api/conv/ProtoConverter.java
@@ -73,15 +73,15 @@ public class ProtoConverter {
     }
 
     public MSG_Notification createNotificationFor(@NonNull Fact t) {
-        MSG_Notification.Builder builder = MSG_Notification.newBuilder().setType(
-                MSG_Notification.Type.Fact);
+        MSG_Notification.Builder builder = MSG_Notification.newBuilder()
+                .setType(MSG_Notification.Type.Fact);
         builder.setFact(toProto(t));
         return builder.build();
     }
 
     public MSG_Notification createNotificationFor(@NonNull UUID id) {
-        MSG_Notification.Builder builder = MSG_Notification.newBuilder().setType(
-                MSG_Notification.Type.Id);
+        MSG_Notification.Builder builder = MSG_Notification.newBuilder()
+                .setType(MSG_Notification.Type.Id);
         builder.setId(toProto(id));
         return builder.build();
     }
@@ -225,8 +225,10 @@ public class ProtoConverter {
     }
 
     public StateForRequest fromProto(MSG_StateForRequest request) {
-        List<UUID> aggIds = request.getAggIdsList().stream().map(this::fromProto).collect(Collectors
-                .toList());
+        List<UUID> aggIds = request.getAggIdsList()
+                .stream()
+                .map(this::fromProto)
+                .collect(Collectors.toList());
         String ns = request.getNsPresent() ? request.getNs() : null;
         return new StateForRequest(aggIds, ns);
     }
@@ -251,8 +253,10 @@ public class ProtoConverter {
         String ns = req.ns();
         MSG_StateForRequest.Builder b = MSG_StateForRequest.newBuilder()
                 .setNsPresent(ns != null)
-                .addAllAggIds(req.aggIds().stream().map(this::toProto).collect(Collectors
-                        .toList()));
+                .addAllAggIds(req.aggIds()
+                        .stream()
+                        .map(this::toProto)
+                        .collect(Collectors.toList()));
 
         if (ns != null)
             b.setNs(ns);

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/BlockingStreamObserver.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/BlockingStreamObserver.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/FactCastSecurityConfiguration.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/FactCastSecurityConfiguration.java
@@ -43,7 +43,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 
 import lombok.extern.slf4j.Slf4j;
-
 import net.devh.boot.grpc.server.autoconfigure.*;
 import net.devh.boot.grpc.server.security.authentication.*;
 

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/FactStoreGrpcService.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/FactStoreGrpcService.java
@@ -34,7 +34,6 @@ import org.springframework.security.access.annotation.*;
 import com.google.common.annotations.*;
 
 import io.grpc.stub.*;
-
 import lombok.*;
 import lombok.extern.slf4j.*;
 import net.devh.boot.grpc.server.service.*;

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcCompressionInterceptor.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcCompressionInterceptor.java
@@ -19,7 +19,6 @@ import org.factcast.grpc.api.*;
 
 import io.grpc.*;
 import io.grpc.ServerCall.*;
-
 import lombok.*;
 import net.devh.boot.grpc.server.interceptor.*;
 

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcObserverAdapter.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcObserverAdapter.java
@@ -23,7 +23,6 @@ import org.factcast.grpc.api.conv.ProtoConverter;
 import org.factcast.grpc.api.gen.FactStoreProto.MSG_Notification;
 
 import io.grpc.stub.StreamObserver;
-
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/PgConfigurationProperties.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/PgConfigurationProperties.java
@@ -63,8 +63,9 @@ public class PgConfigurationProperties implements ApplicationListener<Applicatio
     int queueSize = 1000;
 
     /**
-     * The factor to apply, when fetching/queuing Ids rather than Facts (assuming,
-     * that needs just a fraction of Heap and is way fater to flush to the client)
+     * The factor to apply, when fetching/queuing Ids rather than Facts
+     * (assuming, that needs just a fraction of Heap and is way fater to flush
+     * to the client)
      */
     int idOnlyFactor = 100;
 
@@ -74,7 +75,8 @@ public class PgConfigurationProperties implements ApplicationListener<Applicatio
     CatchupStrategy catchupStrategy = CatchupStrategy.getDefault();
 
     /**
-     * Fetch Size used when filling the Queue, defaults to 4 (25% of the queue-size)
+     * Fetch Size used when filling the Queue, defaults to 4 (25% of the
+     * queue-size)
      */
     int queueFetchRatio = 4;
 

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgPostQueryMatcher.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgPostQueryMatcher.java
@@ -52,8 +52,10 @@ public class PgPostQueryMatcher implements Predicate<Fact> {
         if (canBeSkipped) {
             log.trace("{} post query filtering has been disabled", req);
         } else {
-            this.matchers.addAll(req.specs().stream().map(FactSpecMatcher::new).collect(Collectors
-                    .toList()));
+            this.matchers.addAll(req.specs()
+                    .stream()
+                    .map(FactSpecMatcher::new)
+                    .collect(Collectors.toList()));
         }
     }
 

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgConnectionSupplier.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgConnectionSupplier.java
@@ -50,8 +50,8 @@ public class PgConnectionSupplier {
 
     public PgConnection get() throws SQLException {
         try {
-            return (PgConnection) DriverManager.getDriver(ds.getUrl()).connect(ds.getUrl(),
-                    buildPgConnectionProperties(ds));
+            return (PgConnection) DriverManager.getDriver(ds.getUrl())
+                    .connect(ds.getUrl(), buildPgConnectionProperties(ds));
         } catch (SQLException e) {
             final String msg = "Cannot acquire Connection from DriverManager: " + ds.getUrl();
             log.error(msg, e);

--- a/factcast-store-test/src/main/java/org/factcast/store/test/AbstractFactStoreTest.java
+++ b/factcast-store-test/src/main/java/org/factcast/store/test/AbstractFactStoreTest.java
@@ -973,8 +973,10 @@ public abstract class AbstractFactStoreTest {
 
         Runnable e = mock(Runnable.class);
 
-        uut.lock(NS).on(UUID.randomUUID()).attempt(() -> Attempt.publish(fact(UUID.randomUUID()))
-                .andThen(e));
+        uut.lock(NS)
+                .on(UUID.randomUUID())
+                .attempt(() -> Attempt.publish(fact(UUID.randomUUID()))
+                        .andThen(e));
 
         verify(e).run();
     }
@@ -987,8 +989,9 @@ public abstract class AbstractFactStoreTest {
         Runnable e = mock(Runnable.class);
         Mockito.doThrow(NumberFormatException.class).when(e).run();
 
-        assertThrows(ExceptionAfterPublish.class, () -> uut.lock(NS).on(UUID.randomUUID()).attempt(
-                () -> Attempt.publish(fact(UUID.randomUUID())).andThen(e)));
+        assertThrows(ExceptionAfterPublish.class, () -> uut.lock(NS)
+                .on(UUID.randomUUID())
+                .attempt(() -> Attempt.publish(fact(UUID.randomUUID())).andThen(e)));
         verify(e).run();
     }
 
@@ -1084,14 +1087,16 @@ public abstract class AbstractFactStoreTest {
 
         UUID agg1 = UUID.randomUUID();
 
-        assertThrows(OptimisticRetriesExceededException.class, () -> uut.lock(NS).on(agg1).attempt(
-                () -> {
+        assertThrows(OptimisticRetriesExceededException.class, () -> uut.lock(NS)
+                .on(agg1)
+                .attempt(
+                        () -> {
 
-                    // write conflicting fact first
-                    uut.publish(fact(agg1));
+                            // write conflicting fact first
+                            uut.publish(fact(agg1));
 
-                    return Attempt.publish(fact(agg1));
-                }));
+                            return Attempt.publish(fact(agg1));
+                        }));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
             </licenseHeader>
             <eclipse>
               <file>file://${formatter.config}/eclipse_code_formatter.xml</file>
-              <version>4.7.1</version>
+              <version>4.11.0</version>
             </eclipse>
             <trimTrailingWhitespace />
             <removeUnusedImports />

--- a/src/eclipse/config/eclipse.importorder
+++ b/src/eclipse/config/eclipse.importorder
@@ -1,6 +1,5 @@
 #Organize Import Order
-#Tue Apr 09 18:13:09 CEST 2019
-4=lombok
+4=
 3=com
 2=org
 1=javax

--- a/src/eclipse/config/eclipse_code_formatter.xml
+++ b/src/eclipse/config/eclipse_code_formatter.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<profiles version="12">
+<profiles version="16">
   <profile kind="CodeFormatterProfile" name="FactCast"
-    version="12">
+    version="16">
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations"
-      value="insert" />
-    <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression"
@@ -23,6 +20,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries"
       value="true" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator"
+      value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters"
       value="insert" />
@@ -77,11 +77,10 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits"
       value="do not insert" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration"
-      value="insert" />
-    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for"
       value="insert" />
+    <setting id="org.eclipse.jdt.core.formatter.align_with_spaces"
+      value="false" />
     <setting id="org.eclipse.jdt.core.formatter.disabling_tag"
       value="@formatter:off" />
     <setting
@@ -96,9 +95,6 @@
     <setting
       id="org.eclipse.jdt.core.formatter.blank_lines_after_package"
       value="1" />
-    <setting
-      id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator"
-      value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations"
       value="insert" />
@@ -123,6 +119,9 @@
       id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return"
       value="insert" />
     <setting
@@ -132,6 +131,9 @@
       id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator"
+      value="true" />
+    <setting
       id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line"
       value="false" />
     <setting
@@ -139,9 +141,6 @@
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments"
-      value="insert" />
-    <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator"
@@ -174,17 +173,23 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator"
+      value="16" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression"
       value="do not insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column"
       value="false" />
-    <setting
-      id="org.eclipse.jdt.core.compiler.problem.enumIdentifier"
-      value="error" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter"
       value="insert" />
@@ -210,12 +215,21 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.comment.line_length" value="80" />
     <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags"
       value="true" />
     <setting
+      id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line"
+      value="one_line_never" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression"
       value="do not insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant"
       value="insert" />
@@ -241,6 +255,12 @@
       id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration"
       value="end_of_line" />
     <setting
+      id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line"
+      value="one_line_never" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation"
       value="do not insert" />
     <setting
@@ -249,6 +269,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for"
       value="insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body"
       value="0" />
@@ -259,11 +282,11 @@
       id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line"
       value="false" />
     <setting
-      id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression"
-      value="16" />
-    <setting
       id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause"
       value="common_lines" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator"
+      value="16" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference"
       value="insert" />
@@ -279,6 +302,18 @@
     <setting
       id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call"
       value="16" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator"
+      value="insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator"
+      value="16" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line"
+      value="one_line_never" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator"
+      value="true" />
     <setting
       id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header"
       value="true" />
@@ -312,6 +347,9 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line"
       value="true" />
     <setting
@@ -330,8 +368,8 @@
       id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration"
       value="16" />
     <setting
-      id="org.eclipse.jdt.core.compiler.problem.assertIdentifier"
-      value="error" />
+      id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops"
+      value="16" />
     <setting
       id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment"
       value="false" />
@@ -342,16 +380,19 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing"
       value="do not insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment"
       value="false" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer"
-      value="insert" />
+      id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator"
+      value="0" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator"
+      id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator"
@@ -375,6 +416,9 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources"
       value="do not insert" />
     <setting
@@ -390,7 +434,7 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter"
       value="insert" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration"
+      id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression"
@@ -408,8 +452,8 @@
       id="org.eclipse.jdt.core.formatter.alignment_for_assignment"
       value="0" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body"
-      value="insert" />
+      id="org.eclipse.jdt.core.formatter.alignment_for_module_statements"
+      value="16" />
     <setting
       id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header"
       value="true" />
@@ -417,11 +461,17 @@
       id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant"
       value="do not insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration"
       value="16" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration"
       value="0" />
@@ -441,6 +491,9 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type"
       value="insert" />
     <setting
@@ -456,20 +509,23 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain"
+      value="0" />
+    <setting
       id="org.eclipse.jdt.core.formatter.comment.format_header"
       value="false" />
     <setting
       id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression"
       value="16" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation"
       value="do not insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while"
       value="insert" />
-    <setting
-      id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode"
-      value="enabled" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch"
       value="do not insert" />
@@ -494,11 +550,17 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator"
+      value="0" />
+    <setting
       id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines"
       value="2147483647" />
     <setting
       id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries"
       value="true" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator"
+      value="16" />
     <setting
       id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration"
       value="end_of_line" />
@@ -520,7 +582,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column"
       value="false" />
-    <setting id="org.eclipse.jdt.core.compiler.source" value="1.8" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized"
       value="do not insert" />
@@ -530,7 +594,7 @@
     <setting id="org.eclipse.jdt.core.formatter.tabulation.size"
       value="4" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant"
+      id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression"
@@ -584,8 +648,6 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement"
       value="do not insert" />
     <setting
-      id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8" />
-    <setting
       id="org.eclipse.jdt.core.formatter.brace_position_for_switch"
       value="end_of_line" />
     <setting
@@ -617,6 +679,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.alignment_for_compact_if"
       value="16" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false" />
     <setting
@@ -692,6 +757,9 @@
       id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference"
       value="do not insert" />
     <setting
@@ -704,20 +772,23 @@
       id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer"
       value="do not insert" />
     <setting
-      id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration"
-      value="insert" />
-    <setting
       id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases"
       value="true" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator"
+      value="true" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if"
       value="do not insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon"
       value="do not insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator"
+      value="true" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator"
       value="do not insert" />
@@ -740,6 +811,9 @@
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.comment.indent_tag_description"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line"
       value="false" />
     <setting
@@ -754,6 +828,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters"
       value="do not insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation"
+      value="16" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for"
       value="do not insert" />
@@ -773,14 +850,20 @@
       id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments"
       value="insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator"
       value="do not insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer"
       value="end_of_line" />
     <setting
-      id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator"
+      id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator"
       value="true" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator"
+      value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration"
       value="insert" />
@@ -790,8 +873,6 @@
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch"
       value="do not insert" />
-    <setting id="org.eclipse.jdt.core.compiler.compliance"
-      value="1.8" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference"
       value="do not insert" />
@@ -805,6 +886,9 @@
       id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration"
       value="common_lines" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer"
       value="do not insert" />
     <setting
@@ -814,11 +898,17 @@
       id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations"
       value="do not insert" />
     <setting
+      id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration"
       value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference"
       value="do not insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line"
+      value="one_line_never" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration"
       value="do not insert" />
@@ -834,6 +924,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration"
       value="end_of_line" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator"
+      value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.blank_lines_before_package"
       value="0" />
@@ -853,6 +946,12 @@
       id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header"
       value="0" />
     <setting
+      id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator"
+      value="true" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line"
+      value="false" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while"
       value="do not insert" />
     <setting
@@ -870,6 +969,9 @@
     <setting
       id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header"
       value="true" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation"
+      value="insert" />
     <setting
       id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow"
       value="insert" />
@@ -897,8 +999,14 @@
     <setting id="org.eclipse.jdt.core.formatter.tabulation.char"
       value="space" />
     <setting
+      id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator"
+      value="insert" />
+    <setting
       id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations"
       value="do not insert" />
+    <setting
+      id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation"
+      value="true" />
     <setting
       id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups"
       value="1" />


### PR DESCRIPTION
This reverts the importorder to default values and makes
sure anything not matching these packages goes below. With the
old Formatter (4.7.1) anything not matching was sorted before
lombok for example.

Also updated the formatter settings exported from Eclipse 4.11/2019-03.
This is responsible for the Javadoc changes, only.

(Sorry it took a bit longer. My git tree was apparently broken. I had seen different content in files than what was pushed. FTW.)
