### PR TITLE
Fix Spring Boot 1 example client dependency

### DIFF
--- a/factcast-examples/factcast-example-client-spring-boot1/pom.xml
+++ b/factcast-examples/factcast-example-client-spring-boot1/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <artifactId>factcast-example-client-spring-boot1</artifactId>
   <properties>
-    <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
+    <spring-boot.version>1.5.21.RELEASE</spring-boot.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -64,3 +64,4 @@
     </plugins>
   </build>
 </project>
+


### PR DESCRIPTION
Was erroneously changed (again) with e9f3b950e39bd179f3d808842060c7e981ea1740.

Updated to 1.5.21.RELEASE from 1.5.20.RELEASE.