### PR TITLE
log as info. no need to log error within a working feature

### DIFF
--- a/factcast-core/src/main/java/org/factcast/core/subscription/ReconnectingFactSubscriptionWrapper.java
+++ b/factcast-core/src/main/java/org/factcast/core/subscription/ReconnectingFactSubscriptionWrapper.java
@@ -209,7 +209,7 @@ public class ReconnectingFactSubscriptionWrapper implements Subscription {
             @Override
             public void onError(@NonNull Throwable exception) {
 
-                log.error("Closing & Reconnecting subscription due to onError triggered.",
+                log.info("Closing & Reconnecting subscription due to onError triggered.",
                         exception);
 
                 closeAndDetachSubscription();


### PR DESCRIPTION
as this feature works I recommend to log this as only info